### PR TITLE
Add argocd dashboard app and add dns record

### DIFF
--- a/argocd/dashboard.yaml
+++ b/argocd/dashboard.yaml
@@ -1,0 +1,42 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dashboard
+  namespace: argocd
+spec:
+  project: default
+  syncPolicy:
+    automated: {}
+  source:
+    repoURL: https://github.com/edfincham/homelab.git
+    path: helm/charts/dashboard
+    targetRevision: HEAD
+    helm:
+      releaseName: dashboard
+      valuesObject:
+        dashboardConfig: |
+          pageInfo:
+            title: Home Lab
+          appConfig:
+            theme: callisto
+            layout: auto
+            iconSize: medium
+            language: en
+            disableConfiguration: true
+          sections:
+            - name: GitOps
+              icon: far fa-git
+              items:
+                - title: GitHub
+                  description: HomeLab Source Code
+                  icon: fab fa-github
+                  url: https://github.com/edfincham/homelab
+                - title: ArgoCD
+                  description: GitOps Controller Plane
+                  icon: favicon
+                  url: http://argo.home.lab
+        service:
+          loadBalancerIP: 192.168.0.243
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: dns

--- a/argocd/dns.yaml
+++ b/argocd/dns.yaml
@@ -19,6 +19,8 @@ spec:
         dnsRecords:
         - domain: 192.168.0.242
           address: "argo.home.lab"
+        - domain: 192.168.0.243
+          address: "dashboard.home.lab"
         service:
           loadBalancerIP: 192.168.0.240
   destination:


### PR DESCRIPTION
# Problem
- No argocd app for dashboard
- No DNS record for dashboard LB IP address

# Fix
- Add dashboard argocd application
- Amend DNS application to include dashboard record